### PR TITLE
fix rng bug

### DIFF
--- a/arcade/Core/runCore.m
+++ b/arcade/Core/runCore.m
@@ -72,7 +72,7 @@ else
     end
 end
 if isempty(cfg.rng)
-    cfg.rng = rng(now, 'twister');
+    cfg.rng = rng('shuffle', 'twister');
 else
     logmessage(...
         sprintf('Using predefined random number generator (method=%s, seed=%d)', ...


### PR DESCRIPTION
currently, with `cfg.rng = rng(now, 'twister')`  seed is updated per day, because returned value of `now` is converted to non-negtive integers which is the date of today. This will leave the seed identical between sessions in one day. `rng('shuffle', 'twister')` is more robust.