### PR TITLE
fix iss24 by skipping empty status string

### DIFF
--- a/arcade/EyeServer/CalibrateEyelink.m
+++ b/arcade/EyeServer/CalibrateEyelink.m
@@ -176,7 +176,12 @@ classdef CalibrateEyelink < handle
                 % give reward if we are advancing to a new target
                 [~, statusStr] = Eyelink('ReadFromTracker', 'calibration_status');
                 status = strsplit(statusStr, ' ');
-                currentIndex = str2double(status{4});
+                
+                try
+                    currentIndex = str2double(status{4});
+                catch
+                    continue
+                end
                 
                 if ((currentIndex > previousIndex) && (currentIndex > 1)) ...
                         || ( Eyelink('CalResult') == 0 ) % final target


### PR DESCRIPTION
#24 
a dirty fix. Would be better to figure out why the status string returned by Eyelink is empty at some inquiries.